### PR TITLE
Use Leaflet's map object syntax for clarity.

### DIFF
--- a/Activity1/FinishedCode/script.js
+++ b/Activity1/FinishedCode/script.js
@@ -2,14 +2,14 @@
 
 $(document).ready(function() {
 
-	var map = L.map('map').setView([35.104602, -106.628414], 11);
+	var map = L.map('map', {
+        center: [35.104602, -106.628414],
+        zoom: 11
+    });
 
 	L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	    attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a>',
-	    maxZoom: 18,
-	   
+	    maxZoom: 18
 	}).addTo(map);
 
 });
-
-

--- a/Activity1/README.md
+++ b/Activity1/README.md
@@ -58,13 +58,15 @@ After the document is ready, instantiate your map object.  Set it's center, and 
 ```
 $(document).ready(function() {
 
-    var map = L.map('map').setView([35.104602, -106.628414], 11);
+	var map = L.map('map', {
+        center: [35.104602, -106.628414],
+        zoom: 11
+    });
 
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a>',
-        maxZoom: 18,
-       
-    }).addTo(map);
+	L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	    attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a>',
+	    maxZoom: 18
+	}).addTo(map);
 
 });
 ```


### PR DESCRIPTION
This pull request changes the first activity tutorial to more closely match Leaflet's own documentation. It uses the `.map` constructor's object syntax instead of its parameter-based notation to provide more clarity about the function's capabilities to the new Leaflet user (like myself).